### PR TITLE
chore: bump nixpkgs 25.11 -> 26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772047000,
-        "narHash": "sha256-7DaQVv4R97cii/Qdfy4tmDZMB2xxtyIvNGSwXBBhSmo=",
+        "lastModified": 1785858998,
+        "narHash": "sha256-fKCq5jphd6l/Ms6gc3dptkw/TcKLYub9lQE5g6rbbkc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1267bb4920d0fc06ea916734c11b0bf004bbe17e",
+        "rev": "04607e1165ac22c5fde6dcc54c9e0b3c0487c555",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs = { self, nixpkgs, flake-utils }:
@@ -19,7 +19,8 @@
                 just
                 markdown-link-check
                 mdbook
-                mdbook-linkcheck
+                mdbook-linkcheck2
+                mdbook-mermaid
             ];
           };
         }

--- a/justfile
+++ b/justfile
@@ -1,6 +1,8 @@
 # Serve the mdbook with auto-open
-serve:
+dev:
     cd webcat-documentation && mdbook serve --open
+
+alias serve := dev
 
 # Build the mdbook project
 build:

--- a/webcat-documentation/book.toml
+++ b/webcat-documentation/book.toml
@@ -10,7 +10,7 @@ language = "en"
 [output.html]
 additional-js = ["mermaid.min.js", "mermaid-init.js"]
 
-[output.linkcheck]
+[output.linkcheck2]
 # Perform GETs on public URls
 follow-web-links = true
 


### PR DESCRIPTION
This gets us mdbook v0.5, which is required for built-in "NOTE" admonition support, which closes #31. We also migrate from `mdbook-linkcheck` to a fork, `mdbook-linkcheck2`, due to the lack of v0.5 compat [0].

[0] https://github.com/Michael-F-Bryan/mdbook-linkcheck/pull/98

## example screenshots

### before

<img width="815" height="254" alt="before" src="https://github.com/user-attachments/assets/12c550b1-b1ba-4fdd-8853-2dd0936eb90b" />

### after

<img width="830" height="239" alt="after" src="https://github.com/user-attachments/assets/0f174a64-2086-45ce-94a8-84e327a90892" />

