### PR TITLE
Adjust links of the form ./section/README.md

### DIFF
--- a/webcat-documentation/src/architecture/README.md
+++ b/webcat-documentation/src/architecture/README.md
@@ -7,4 +7,4 @@ This section describes WEBCAT's system design and infrastructure.
 ![Full architecture summary](../charts/architectureV2.svg)
 
 ### Components
-- [Enrollment Infrastructure](./enrollment-infrastructure) - WEBCAT enrollment infrastructure chain design
+- [Enrollment Infrastructure](./enrollment-infrastructure/) - WEBCAT enrollment infrastructure chain design

--- a/webcat-documentation/src/architecture/README.md
+++ b/webcat-documentation/src/architecture/README.md
@@ -7,4 +7,4 @@ This section describes WEBCAT's system design and infrastructure.
 ![Full architecture summary](../charts/architectureV2.svg)
 
 ### Components
-- [Enrollment Infrastructure](./enrollment-infrastructure/README.md) - WEBCAT enrollment infrastructure chain design
+- [Enrollment Infrastructure](./enrollment-infrastructure) - WEBCAT enrollment infrastructure chain design

--- a/webcat-documentation/src/for-contributors.md
+++ b/webcat-documentation/src/for-contributors.md
@@ -5,6 +5,6 @@ operator.
 
 ## Enrollment infrastructure development
 
-See [Enrollment Infrastructure](./architecture#enrollment-infrastructure) in the Architecture section for the WEBCAT infra chain design, setup, and operations (validators, oracles, admins, CometBFT, and development roadmap).
+See [Enrollment Infrastructure](./architecture/#enrollment-infrastructure) in the Architecture section for the WEBCAT infra chain design, setup, and operations (validators, oracles, admins, CometBFT, and development roadmap).
 
 ## Enrollment infrastructure operator

--- a/webcat-documentation/src/for-contributors.md
+++ b/webcat-documentation/src/for-contributors.md
@@ -5,6 +5,6 @@ operator.
 
 ## Enrollment infrastructure development
 
-See [Enrollment Infrastructure](./architecture/README.md#enrollment-infrastructure) in the Architecture section for the WEBCAT infra chain design, setup, and operations (validators, oracles, admins, CometBFT, and development roadmap).
+See [Enrollment Infrastructure](./architecture#enrollment-infrastructure) in the Architecture section for the WEBCAT infra chain design, setup, and operations (validators, oracles, admins, CometBFT, and development roadmap).
 
 ## Enrollment infrastructure operator

--- a/webcat-documentation/src/for-infrastructure-operators.md
+++ b/webcat-documentation/src/for-infrastructure-operators.md
@@ -5,4 +5,4 @@ This section is for anyone running or operating WEBCAT infrastructure (validator
 TK
 
 - [WEBCAT Validator Operator](./contributors/validator-operator.md)
-- [Enrollment Infrastructure Architecutre](./architecture/enrollment-infrastructure/README.md)
+- [Enrollment Infrastructure Architecutre](./architecture/enrollment-infrastructure/)

--- a/webcat-documentation/src/site-operators/GA.md
+++ b/webcat-documentation/src/site-operators/GA.md
@@ -10,7 +10,7 @@ Site enrollment is the process of:
 This page focuses on how to use WEBCAT-provided GitHub Actions workflows to
 integrate `webcat-cli` with Sigstore into a static site's CI/CD pipeline without
 breaking reproducibility. The prerequisites are covered in the [`webcat-cli`
-documentation](./cli/README.md): in particular [choosing between Sigstore and
+documentation](./cli/): in particular [choosing between Sigstore and
 Sigsum](./cli/sigsum-or-sigstore.md) and the [`webcat.config.json`
 schema](./cli/config-schema.md).
 

--- a/webcat-documentation/src/site-operators/manual.md
+++ b/webcat-documentation/src/site-operators/manual.md
@@ -1,7 +1,7 @@
 # Manual Signing
 The following procedure describes how to use the WEBCAT CLI to generate enrollment and metadata information for WEBCAT. It uses Sigsum.
 
-> For full command and flag details, see the [`webcat-cli` reference](./cli/README.md). For a condensed, copy-pasteable version of this same workflow, see the [end-to-end example](./cli/end-to-end.md).
+> For full command and flag details, see the [`webcat-cli` reference](./cli/). For a condensed, copy-pasteable version of this same workflow, see the [end-to-end example](./cli/end-to-end.md).
 
 ### Create Sigsum Keys
 


### PR DESCRIPTION
Not sure if they ever worked? but links of the form `./section/README.md` currently result in a 404. Removing the `README.md` fixes them.